### PR TITLE
Add 403bypasser plugin

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -24,5 +24,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEA+du2fw/I+CV6MKEpu0aJ1ki2+MO2V0SnaRB91+GbHwQ=",
     "repository": "caido-community/authmatrix"
+  },
+  {
+    "id": "bypasser",
+    "name":"403Bypasser",
+    "license": "CC0-1.0",
+    "description": "Bypass a 403 page with a set of templates",
+    "author": {
+      "name": "bebiks",
+      "email": "bebiks@cvssadvisor.com",
+      "url": "http://x.com/bebiksior"
+    },
+    "public_key":"MCowBQYDK2VwAyEA7hd15kPWlDAzJmMXXFRbVDD83T+0AWVk6OlgLwAgwFQ=",
+    "repository": "bebiksior/Caido403Bypasser"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL
Link to my plugin package:
http://github.com/bebiksior/Caido403Bypasser

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
