### PR TITLE
Add Screening Drawing

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -67,7 +67,7 @@
   {
     "id": "cursor-pen",
     "name": "Screening Drawing",
-    "license": "CC0-1.0",
+    "license": "MIT",
     "description": "A plugin that turns the cursor into a drawing pen",
     "author": {
       "name": "Tur24Tur / BugBountyZip",

--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -67,7 +67,6 @@
   {
     "id": "cursor-pen",
     "name": "Screening Drawing",
-    "version": "2.0.3",
     "license": "CC0-1.0",
     "description": "A plugin that turns the cursor into a drawing pen",
     "author": {
@@ -76,6 +75,6 @@
       "url": "https://github.com/BugBountyzip"
     },
     "public_key": "MCowBQYDK2VwAyEA+kw/aGY+CpXIbOD6pjtwugdRbc59+yp7Ep/7ENr2xXc=",
-    "repository": "BugBountyzip/cursor-pen"
+    "repository": "BugBountyzip/CaidoDrawing"
   }
 ]

--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -63,5 +63,19 @@
     },
     "public_key":"MCowBQYDK2VwAyEA2/J0S50jHKkeUah5eULQEK8eNcaJ1hCd62NLAO5MIWI=",
     "repository": "bebiksior/CaidoThemes"
+  },
+  {
+    "id": "cursor-pen",
+    "name": "Screening Drawing",
+    "version": "2.0.3",
+    "license": "CC0-1.0",
+    "description": "A plugin that turns the cursor into a drawing pen",
+    "author": {
+      "name": "Tur24Tur / BugBountyZip",
+      "email": "no-reply@NoBugEscapes.com",
+      "url": "https://github.com/BugBountyzip"
+    },
+    "public_key": "MCowBQYDK2VwAyEA+kw/aGY+CpXIbOD6pjtwugdRbc59+yp7Ep/7ENr2xXc=",
+    "repository": "BugBountyzip/cursor-pen"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

https://github.com/BugBountyzip/CaidoDrawing/

Link to my plugin package:

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows : Yes
  - [x] macOS : NO
  - [ ] Linux : No
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
