### PR TITLE
Update plugin_packages.json to add Quickssrf

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -100,5 +100,17 @@
     },
     "public_key": "MCowBQYDK2VwAyEAEkwo09jye0OavdTW7SeBwmMRo3cjVEHc666Yn271Ns8=",
     "repository": "BugBountyzip/CaidoFonts"
+  },{
+    "id": "quickssrf",
+    "name": "QuickSSRF",
+    "license": "MIT",
+    "description": "Real-time Interaction Monitoring with Interactsh",
+    "author": {
+      "name": "w2xim3",
+      "email": "dev@caido.io",
+      "url": "https://github.com/caido-community/quickssrf"
+    },
+    "public_key": "MCowBQYDK2VwAyEAeTpbm+s6IsPfUHSa/O8TxyI4gAQIyL1ZVvaAb2GC3xs=",
+    "repository": "caido-community/quickssrf"
   }
 ]


### PR DESCRIPTION
Add QuickSSRF

# I am submitting a new Plugin Package

## Repository URL

<!--- Paste a link to your repo here for easy access -->

Link to my plugin package:

## Release Checklist

- [x] I have tested the plugin on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
