### PR TITLE
Add workflows-store plugin

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -180,5 +180,18 @@
     },
     "public_key":"MCowBQYDK2VwAyEAZYlZX2mMM/v+N45u4PbAl5WOICfZHbK2rRMmVD/ZAVs=",
     "repository": "caido-community/devtools"
+  },
+  {
+    "id": "workflows-store",
+    "name": "Workflows Store",
+    "license": "MIT",
+    "description": "Collection of community-built workflows",
+    "author": {
+        "name": "Caido Labs Inc.",
+        "email": "dev@caido.io",
+        "url": "https://caido.io"
+    },
+    "public_key":"MCowBQYDK2VwAyEAfqyimGX/rO9Cq+O/xnSVZTKiN6xlDVDmGpSjU78r8hs=",
+    "repository": "caido-community/workflows"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL
Link to my plugin package:
https://github.com/caido-community/workflows

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
