### PR TITLE
Add jxscout-caido

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -193,5 +193,18 @@
     },
     "public_key":"MCowBQYDK2VwAyEAfqyimGX/rO9Cq+O/xnSVZTKiN6xlDVDmGpSjU78r8hs=",
     "repository": "caido-community/workflows"
+  },
+  {
+    "id": "jxscout-caido",
+    "name": "JXScout",
+    "license": "MIT",
+    "description": "Plugin to ingest requests from Caido into jxscout",
+    "author": {
+      "name": "Francisco Neves",
+      "email": "dev@caido.io",
+      "url": "https://github.com/francisconeves97"
+    },
+    "public_key": "MCowBQYDK2VwAyEAMqk0FKdu51rkKM7KOPHS9talB12F2lFFK4QIoXPfQYU=",
+    "repository": "francisconeves97/jxscout-caido"
   }
 ]


### PR DESCRIPTION
After suggestion from the community (https://discord.com/channels/1110206757227216916/1181247321464377404/1356351040013865052) I am adding jxscout-caido plugin to Caido Store

# I am submitting a new Plugin Package

## Repository URL

https://github.com/francisconeves97/jxscout-caido

Link to my plugin package: https://github.com/francisconeves97/jxscout-caido

## Release Checklist

- [X] I have tested the plugin on
  - [ ] Windows
  - [X] macOS
  - [ ] Linux
- [X] My GitHub release contains all required files (after release 0.3.0)
  - [X] `plugin_package.zip`
  - [X] `plugin_package.zip.sig`
- [X] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [X] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [X] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [X] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [X] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [X] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
