### PR TITLE
Transfer the repo to community

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -118,7 +118,7 @@
   },
   {
     "id": "notesplusplus",
-    "name": "CaidoNotesPlusPlus",
+    "name": "Notes++",
     "license": "MIT",
     "description": "Caido plugin for markdown based notes",
     "author": {
@@ -127,7 +127,7 @@
       "url": "https://twitter.com/_StaticFlow_"
     },
     "public_key": "MCowBQYDK2VwAyEAo1oWyQvff1+B5iaUVhXZYd/LObrOqghmF5fMeInpMGk=",
-    "repository": "Static-Flow/CaidoNotesPlusPlus"
+    "repository": "caido-community/NotesPlusPlus"
   },
   {
     "id": "convert-tools",
@@ -174,11 +174,11 @@
     "license": "MIT",
     "description": "Hot-reloading for faster Caido plugin development",
     "author": {
-        "name": "Caido Labs Inc.",
-        "email": "dev@caido.io",
-        "url": "https://caido.io"
+      "name": "Caido Labs Inc.",
+      "email": "dev@caido.io",
+      "url": "https://caido.io"
     },
-    "public_key":"MCowBQYDK2VwAyEAZYlZX2mMM/v+N45u4PbAl5WOICfZHbK2rRMmVD/ZAVs=",
+    "public_key": "MCowBQYDK2VwAyEAZYlZX2mMM/v+N45u4PbAl5WOICfZHbK2rRMmVD/ZAVs=",
     "repository": "caido-community/devtools"
   },
   {
@@ -187,11 +187,11 @@
     "license": "MIT",
     "description": "Collection of community-built workflows",
     "author": {
-        "name": "Caido Labs Inc.",
-        "email": "dev@caido.io",
-        "url": "https://caido.io"
+      "name": "Caido Labs Inc.",
+      "email": "dev@caido.io",
+      "url": "https://caido.io"
     },
-    "public_key":"MCowBQYDK2VwAyEAfqyimGX/rO9Cq+O/xnSVZTKiN6xlDVDmGpSjU78r8hs=",
+    "public_key": "MCowBQYDK2VwAyEAfqyimGX/rO9Cq+O/xnSVZTKiN6xlDVDmGpSjU78r8hs=",
     "repository": "caido-community/workflows"
   },
   {


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

<!--- Paste a link to your repo here for easy access -->

Moving the repo to caido-community

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
