### PR TITLE
Update plugin_packages.json

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -232,5 +232,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEA18AIEbzfWxfEtqxZrn/1b0CQ3O7FpJCNd+WwiCtIaJ4=",
     "repository": "caido-community/drop"
-  }
+  },
+  {
+  "id": "jwt-analyzer",
+  "name": "JWT Analyzer",
+  "license": "MIT",
+  "description": "Detect, analyze, test and Attack JSON Web Tokens in web traffic",
+  "author": {
+    "name": "Amr Elsagaei",
+    "email": "info@amrelsagaei.com",
+    "url": "https://amrelsagaei.com"
+  },
+  "public_key": "MCowBQYDK2VwAyEAXru6JmKshtb2uZYF2VgLSoDFtARq6T05orqbv8JqYXk=",
+  "repository": "amrelsagaei/JWT-Analyzer"
+}
 ]


### PR DESCRIPTION
Adding JWT Analyzer plugin to Caido Plugins Store.

# I am submitting a new Plugin Package

## Repository URL

[JWT Analyzer](https://github.com/amrelsagaei/JWT-Analyzer)

Link to my plugin package:
[JWT-Analyzer.zip](https://github.com/amrelsagaei/JWT-Analyzer/releases/download/1.0.0/plugin_package.zip)

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
