### PR TITLE
Add ExploitGenerator

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -258,5 +258,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEACD0ZC+Cw5ielTgSspgN5aVHMEkamTSqj9pJie5RHWyc=",
     "repository": "evanconnelly/squash"
+  },
+  {
+    "id": "exploit-generator",
+    "name": "Exploit Generator",
+    "license": "MIT",
+    "description": "Generate customizable PoC exploit scripts in multiple languages from HTTP requests.",
+    "author": {
+      "name": "stealthcopter",
+      "email": "caido@stealthcopter.com",
+      "url": "https://sec.stealthcopter.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEA814pfexgpP7LMgxrKQvsyREjDiqmZDGpwA/5PXY08wM=",
+    "repository": "stealthcopter/CaidoExploitGenerator"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

Link to my plugin package:
https://github.com/stealthcopter/CaidoExploitGenerator/

## Release Checklist

- [X] I have tested the plugin on
  - [ ] Windows
  - [ ] macOS
  - [X] Linux
- [X] My GitHub release contains all required files
  - [X] `plugin_package.zip`
  - [X] `plugin_package.zip.sig`
- [X] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [X] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [X] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [X] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [X] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [X] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
