### PR TITLE
Update plugin_packages.json

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -271,5 +271,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEA814pfexgpP7LMgxrKQvsyREjDiqmZDGpwA/5PXY08wM=",
     "repository": "stealthcopter/CaidoExploitGenerator"
+  },
+  {
+    "id": "caido-newrequests",
+    "name": "NewRequests",
+    "license": "MIT",
+    "description": "Provides a hotkey (default cmd+n) to apply a HTTPQL query for new requests (`row.id.gt:<current last request>`)",
+    "author": {
+      "name": "Martin Haunschmid",
+      "email": "contact@martinhaunschmid.com",
+      "url": "https://martinhaunschmid.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEAsSAO8ml6yamPfWX/kV2FUFgr/WxBqdlZoe1yTNr56Xo=",
+    "repository": "martinhaunschmid/caido-newrequests"
   }
 ]


### PR DESCRIPTION
Added caido-newrequests

# I am submitting a new Plugin Package

## Repository URL

https://github.com/martinhaunschmid/caido-newrequests

Link to my plugin package:

## Release Checklist

- [x] I have tested the plugin on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
