### PR TITLE
Add cerebrum

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -284,5 +284,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAO26EMwX4yA3RdYKT0FFGN3n5kUynF5SVFxNrLWc6ZsM=",
     "repository": "yeswehack/yeswecaido"
+  },
+  {
+    "id": "cerebrum",
+    "name": "Cerebrum",
+    "license": "MIT",
+    "description": "A simple organizer-like plugin for Caido to help you manage, annotate, and sort HTTP requests.",
+    "author": {
+      "name": "DewSecOff",
+      "email": "DewSecOff@protonmail.com",
+      "url": "https://github.com/DewSecOff/Caido-Plugin-Cerebrum"
+    },
+    "public_key": "MCowBQYDK2VwAyEASa/hE1TRgfQyCRzmVTR1FHxjXtT3Pe+khlSlq81AlUY=",
+    "repository": "DewSecOff/Caido-Plugin-Cerebrum"
   }
 ]


### PR DESCRIPTION
Add Cerebrum plugin to the Caido store

# I am submitting a new Plugin Package

## Repository URL

https://github.com/DewSecOff/Caido-Plugin-Cerebrum

Link to my plugin package: https://github.com/DewSecOff/Caido-Plugin-Cerebrum/releases/tag/1.0.1

## Release Checklist

- [ ] I have tested the plugin on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
