### PR TITLE
Add plugin tab renammer

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -336,5 +336,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEA79GS1nlRq7UJobFjpUQo7pVo+SfR2+Gq2wKW4ncj/w4=",
     "repository": "amrelsagaei/Chatio"
-  }
+  },
+  {
+  "id": "tab-renammer",
+  "name": "Tab Renamer",
+  "license": "MIT",
+  "description": "Plugin used to rename automaticly tab in replay section",
+  "author": {
+    "name": "Serizao",
+    "email": "dev@caido.io",
+    "url": "https://github.com/serizao/tab-renamme"
+  },
+  "public_key": "MCowBQYDK2VwAyEAamNXDc4y/9fASC2qHAerTCq0sCKZrypIOl0F000d+Es=",
+  "repository": "serizao/tab-renamme"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

[<!--- Paste a link to your repo here for easy access -->

Link to my plugin package:](https://github.com/Serizao/tab-renammer)

## Release Checklist

- [ x] I have tested the plugin on
  - [ x] Windows
  - [ ] macOS
  - [ ] Linux
- [ x] My GitHub release contains all required files
  - [ x] `plugin_package.zip`
  - [ x] `plugin_package.zip.sig`
- [ x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [ x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [ x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [ x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [ x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [ x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
