### PR TITLE
Add OpenApi

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -443,7 +443,7 @@
   },
   {
     "id": "openapi-tester",
-    "name": "OpenApi",
+    "name": "OpenAPI",
     "license": "MIT",
     "description": "Accelerate endpoint testing by providing schemas",
     "author": {


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

<!--- Paste a link to your repo here for easy access -->

Link to my plugin package: https://github.com/MDGDSS/caido-openapi

## Release Checklist

- [x] I have tested the plugin on
  - [X ] Windows
  - [x] macOS
  - [x] Linux
- [X ] My GitHub release contains all required files
  - [X ] `plugin_package.zip`
  - [X ] `plugin_package.zip.sig`
- [X ] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [X ] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [ X] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [X ] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [ X] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [X ] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
