### PR TITLE
feat: add bytecap plugin

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -361,5 +361,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAzu4fQBltUyHwwjIc4X6fM1RnqWBjduegUQRD4oIUX6c=",
     "repository": "caido-community/scanner"
+  },
+  {
+    "id": "bytecap",
+    "name": "ByteCap",
+    "license": "MIT",
+    "description": "Cap and split workspace files by size, ideal for proxy files/log uploads with file size limits",
+    "author": {
+      "name": "ads dawson",
+      "email": "ads@offsecmoose.xyz",
+      "url": "https://github.com/GangGreenTemperTatum"
+    },
+    "public_key": "MCowBQYDK2VwAyEAIH6nesHsT+U6myM6Z66JxXes2CI5/uNEWfX3R9LscLg=",
+    "repository": "GangGreenTemperTatum/ByteCap"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

<!--- Paste a link to your repo here for easy access -->

Link to my plugin package:
https://github.com/GangGreenTemperTatum/Bytecap

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files (GH is currently down / intermittent)
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
