### PR TITLE
Add GraphQL Analyzer

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -386,6 +386,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAIH6nesHsT+U6myM6Z66JxXes2CI5/uNEWfX3R9LscLg=",
     "repository": "GangGreenTemperTatum/ByteCap"
+  },{
+    "id": "graphql-analyzer",
+    "name": "GraphQL Analyzer",
+    "license": "MIT",
+    "description": "Plugin for GraphQL schema discovery, visualization, and advanced security",
+    "author": {
+      "name": "Amr Elsagaei",
+      "email": "info@amrelsagaei.com",
+      "url": "https://amrelsagaei.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEAO29lZ32flhJc/IMUkDzK2GypJynAOLxmeKzlfHbDnjA=",
+    "repository": "amrelsagaei/GraphQL-Analyzer"
   },
   {
     "id": "ebka-ai-assistant",


### PR DESCRIPTION
# I am submitting a new Plugin Package

[amrelsagaei/GraphQL-Analyzer](https://github.com/amrelsagaei/GraphQL-Analyzer)


Link to my plugin package: https://github.com/amrelsagaei/GraphQL-Analyzer/releases/tag/1.0.0

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] GitHub Tag name matches the exact version number specified in my `manifest.json`
- [x] The `id` in my `manifest.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
