### PR TITLE
Add SSRFind plugin

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -739,7 +739,8 @@
     },
     "public_key": "MCowBQYDK2VwAyEA+RUKGA2IR9VlJdMDEu6AuzfXCkl7RAsvhCmLr0EPXkc=",
     "repository": "d0xng/SSRFind"
-
+  },
+  {
     "id": "js-analyzer",
     "name": "JS Analyzer",
     "license": "MIT",

--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -726,5 +726,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAuQ+CT3vItm4767dEntua4PLWFOV5KnXY19UNKvljyHs=",
     "repository": "sp1r1tt/Mass-Assignment-Radar"
-  }  
+  },
+  {
+    "id": "ssrfind",
+    "name": "SSRFind",
+    "license": "MIT",
+    "description": "Passive SSRF detection with phased probing and OOB confirmation",
+    "author": {
+      "name": "d0xng",
+      "email": "letoilefederico@gmail.com",
+      "url": "https://github.com/d0xng/SSRFind"
+    },
+    "public_key": "MCowBQYDK2VwAyEA+RUKGA2IR9VlJdMDEu6AuzfXCkl7RAsvhCmLr0EPXkc=",
+    "repository": "d0xng/SSRFind"
+  }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

https://github.com/d0xng/SSRFind

Link to my plugin package:

https://github.com/d0xng/SSRFind/releases/download/v0.1.0/plugin_package.zip

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] Release immutability is enabled
- [x] GitHub Tag name matches the version number specified in my `caido.config.json`
- [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
