### PR TITLE
Add IIS Tilde Enumeration

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -752,5 +752,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAuPxuuzQN+cpZu7T4NzwaiLP1BN7R5Q6zqBVA3vWdWOg=",
     "repository": "ChrisCZ2/RepoExplorer"
-  }  
+  },
+  {
+    "id": "iis-tilde-enumeration",
+    "name": "IIS Tilde Enumeration",
+    "license": "MIT",
+    "description": "Enumerate IIS 8.3 shortnames using differential tilde probes.",
+    "author": {
+      "name": "Hackerest",
+      "email": "support@hackerest.com",
+      "url": "https://hackerest.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEAPNTjElLMLZZQ5LIn/Vl3L/v2RHpyatwsGqYuu5aP+3E=",
+    "repository": "Hackerest/CaidoIISTildeEnumeration"
+  }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

[https://github.com/Hackerest/CaidoIISTildeEnumeration](https://github.com/Hackerest/CaidoIISTildeEnumeration)

Link to my plugin package:

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] Release immutability is enabled
- [x] GitHub Tag name matches the version number specified in my `caido.config.json`
- [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
