### PR TITLE
Add ReqRes Exporter plugin details

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "reqres-exporter",
+    "name": "ReqRes Exporter",
+    "license": "MIT",
+    "description": "Copy or save HTTP request+response pairs to clipboard or file with one click.",
+    "author": {
+      "name": "Jakob Pachmann",
+      "email": "jakob.pachmann@proton.me",
+      "url": "https://github.com/v0xyc0n"
+    },
+    "public_key": "MCowBQYDK2VwAyEA0uLlulDp0TC0Et3AMJWGgA8yTCHQA5znCNKz8MIlJs8=",
+    "repository": "v0xyc0n/caido-reqres-exporter"
+  },
+  {
     "id": "authmatrix",
     "name": "AuthMatrix",
     "license": "MIT",

--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -830,5 +830,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAjCoIKJEyiEx6awLsxj6/WmOWvFlRTuURntX7U0+0UoA=",
     "repository": "davidus27/ParamLogger"
+  },
+  {
+    "id": "reqres-exporter",
+    "name": "ReqRes Exporter",
+    "license": "MIT",
+    "description": "Copy or save HTTP request+response pairs to clipboard or file with one click.",
+    "author": {
+      "name": "Jakob Pachmann",
+      "email": "jakob.pachmann@proton.me",
+      "url": "https://github.com/v0xyc0n"
+    },
+    "public_key": "MCowBQYDK2VwAyEA0uLlulDp0TC0Et3AMJWGgA8yTCHQA5znCNKz8MIlJs8=",
+    "repository": "v0xyc0n/caido-reqres-exporter"
   }
 ]


### PR DESCRIPTION
Added a new plugin 'ReqRes Exporter'.

# I am submitting a new Plugin Package

## Repository URL

Link to my plugin package: https://github.com/v0xyc0n/caido-reqres-exporter

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] Release immutability is enabled
- [x] GitHub Tag name matches the version number specified in my `caido.config.json`
- [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
