### PR TITLE
Add ShadowShell plugin to plugin_packages.json

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -752,5 +752,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAuPxuuzQN+cpZu7T4NzwaiLP1BN7R5Q6zqBVA3vWdWOg=",
     "repository": "ChrisCZ2/RepoExplorer"
-  }  
+  },
+  {
+    "id": "shadowshell",
+    "name": "ShadowShell",
+    "license": "MIT",
+    "description": "Multi-terminal plugin for Caido with AI presets and instant Cmd+J access",
+    "author": {
+      "name": "hahwul",
+      "email": "hahwul@gmail.com",
+      "url": "https://www.hahwul.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEAjpvyPGmqgAQyiXEN4DtR345SgvmnfptLcBQ2VVPnKKc=",
+    "repository": "hahwul/ShadowShell"
+  }
 ]

--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -986,5 +986,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEA3u/vKRbgONuUKYaeprFbpWCjpclu2jNmYULZvlChuc0=",
     "repository": "amrelsagaei/race"
+  },
+  {
+    "id": "shadowshell",
+    "name": "ShadowShell",
+    "license": "MIT",
+    "description": "Multi-terminal plugin for Caido with AI presets and instant Cmd+J access",
+    "author": {
+      "name": "hahwul",
+      "email": "hahwul@gmail.com",
+      "url": "https://www.hahwul.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEAjpvyPGmqgAQyiXEN4DtR345SgvmnfptLcBQ2VVPnKKc=",
+    "repository": "hahwul/ShadowShell"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

https://github.com/hahwul/ShadowShell

## Release Checklist

- [x] I have tested the plugin on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] Release immutability is enabled
- [x] GitHub Tag name matches the version number specified in my `caido.config.json`
- [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
