### PR TITLE
Add the DOMLogger++ plugin

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -65,6 +65,19 @@
     "repository": "BugBountyzip/CaidoDrawing"
   },
   {
+    "id": "domloggerpp",
+    "name": "DOMLogger++",
+    "license": "GPL-3.0",
+    "description": "A browser extension that allows you to monitor, intercept, and debug JavaScript sinks based on customizable configurations.",
+    "author": {
+      "name": "kevin-mizu",
+      "email": "kevin.mizu@protonmail.com",
+      "url": "https://x.com/kevin_mizu"
+    },
+    "public_key": "MCowBQYDK2VwAyEA4D3AtXZmlqQmxQrHKyqFFHNkIg9skWN8beWvnp0cD+Y=",
+    "repository": "kevin-mizu/domloggerpp-caido"
+  },
+  {
     "id": "pwnfox",
     "name": "PwnFox",
     "license": "MIT",


### PR DESCRIPTION
Added DOMLogger plugin with author details and repository.

# I am submitting a new Plugin Package

## Repository URL

https://github.com/kevin-mizu/domloggerpp-caido

Link to my plugin package:

## Release Checklist

- [X] I have tested the plugin on
  - [ ] Windows
  - [ ] macOS
  - [X] Linux
- [X] My GitHub release contains all required files
  - [X] `plugin_package.zip`
  - [X] `plugin_package.zip.sig`
- [X] Release immutability is enabled
- [X] GitHub Tag name matches the version number specified in my `caido.config.json`
- [X] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [X] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [X] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [X] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [X] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
