### PR TITLE
Add Drift plugin to plugin_packages.json

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -817,5 +817,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAjCoIKJEyiEx6awLsxj6/WmOWvFlRTuURntX7U0+0UoA=",
     "repository": "davidus27/ParamLogger"
+  },
+  {
+    "id": "drift",
+    "name": "Drift",
+    "license": "MIT",
+    "description": "Security AI helper for Caido: pipes your local Claude Code / Gemini / Codex / Copilot CLI through 18 MCP tools for manual web security testing. Local-first, no API keys.",
+    "author": {
+      "name": "six2dez",
+      "email": "six2dez@gmail.com",
+      "url": "https://github.com/six2dez/drift"
+    },
+    "public_key": "MCowBQYDK2VwAyEAiIogh/4GdtqySQlSJdOfFhktZAXnJwdNwxXm68m0tiM=",
+    "repository": "six2dez/drift"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

https://github.com/six2dez/drift

## Release Checklist

- [X] I have tested the plugin on
  - [X] Windows
  - [X] macOS
  - [X] Linux
- [X] My GitHub release contains all required files
  - [X] `plugin_package.zip`
  - [X] `plugin_package.zip.sig`
- [X] Release immutability is enabled
- [X] GitHub Tag name matches the version number specified in my `caido.config.json`
- [X] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [X] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [X] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [X] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [X] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
