### PR TITLE
Add Stash (v0.1.1)

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -869,5 +869,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEA0uLlulDp0TC0Et3AMJWGgA8yTCHQA5znCNKz8MIlJs8=",
     "repository": "v0xyc0n/caido-reqres-exporter"
+  },
+  {
+    "id": "stash",
+    "name": "Stash",
+    "license": "MIT",
+    "description": "Bookmark HTTP History requests so they are easy to find, review, and reopen later.",
+    "author": {
+      "name": "Caleb Kinney",
+      "email": "caleb@typeerror.com",
+      "url": "https://typeerror.com"
+    },
+    "public_key": "MCowBQYDK2VwAyEAxymXo2ReE6hKMB3163HtYir8+MbAdD80U3GOlDXjb5U=",
+    "repository": "TypeError/stash"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

Link to my plugin package:

https://github.com/TypeError/stash

Release:

https://github.com/TypeError/stash/releases/tag/0.1.0

## Release Checklist

* [ ] I have tested the plugin on

  * [ ] Windows
  * [x] macOS
  * [ ] Linux
* [x] My GitHub release contains all required files

  * [x] `plugin_package.zip`
  * [x] `plugin_package.zip.sig`
* [x] Release immutability is enabled
* [x] GitHub Tag name matches the version number specified in my `caido.config.json`
* [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
* [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
* [x] I have read the developer policy at https://developer.caido.io/policy.html, and have assessed my plugin package adherence to this policy.
* [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
* [x] My project respects and is compatible with the original license of any third-party code that I'm using.
  I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.

## Notes

Stash is a lightweight Caido plugin for bookmarking interesting HTTP History requests so they are easy to find, review, and reopen later.

The idea was inspired by @rhynorater’s “Becoming a Caido Power User” talk at Bug Bounty Village during DEF CON 33, where he mentioned a bookmarks plugin as part of his Caido wishlist.

This first release is intentionally focused on one core workflow: stash an interesting request, keep testing, then reopen or send it to Replay when needed.
