### PR TITLE
Add PDF Preview plugin to plugin_packages.json

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -882,5 +882,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAxymXo2ReE6hKMB3163HtYir8+MbAdD80U3GOlDXjb5U=",
     "repository": "TypeError/stash"
+  },
+    {
+    "id": "pdf-preview",
+    "name": "PDF Preview",
+    "license": "MIT",
+    "description": "Preview PDF HTTP responses directly in the Response viewer using pdf.js",
+    "author": {
+      "name": "William Le Berre",
+      "email": "william.leberre@gmail.com",
+      "url": "https://github.com/serizao"
+    },
+    "public_key": "MCowBQYDK2VwAyEAaexrLuktzsbOMrm1qJbxYJXIOz8wRsMEQ+omv0YOFW8=",
+    "repository": "serizao/caidoPDF"
   }
 ]


### PR DESCRIPTION
Added a new plugin entry for PDF Preview with details.

# I am submitting a new Plugin Package

## Repository URL

<!--- Paste a link to your repo here for easy access -->

Link to my plugin package:

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
-  [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] Release immutability is enabled
- [x] GitHub Tag name matches the version number specified in my `caido.config.json`
- [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.
