### PR TITLE
Add Disclosure Lookup (caido-lookup)

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -921,5 +921,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAVIMaBTGYifd0X7/iRXLdxDlDajEyqx5XxkfoVIodqzs=",
     "repository": "V3locidad/h1-caido"
+  },
+  {
+    "id": "caido-lookup",
+    "name": "Disclosure Lookup",
+    "license": "MIT",
+    "description": "Look up the security-disclosure contact for any host via lookup.disclose.io. Right-click a request to find where to report a vulnerability.",
+    "author": {
+      "name": "disclose.io",
+      "email": "hello@disclose.io",
+      "url": "https://github.com/disclose"
+    },
+    "public_key": "MCowBQYDK2VwAyEAxRcCJy1dsCeQVMKLtQBUuCv8T/FWI/5l2MiR3X/9Aw8=",
+    "repository": "disclose/caido-lookup"
   }
 ]


### PR DESCRIPTION
Adds **Disclosure Lookup** to the store.

Finds the security-disclosure contact for any host via [lookup.disclose.io](https://lookup.disclose.io) — right-click a request and choose *Find disclosure contact*, or use the Disclosure Lookup page. Sends only the host to the lookup API; nothing else from the request.

- **Repository:** https://github.com/disclose/caido-lookup
- **Release:** [v0.1.0](https://github.com/disclose/caido-lookup/releases/tag/v0.1.0) — signed package (`caido-lookup.zip` + `caido-lookup.zip.sig` + `public.pem`)
- **License:** MIT
- A [disclose.io](https://disclose.io) project.

Frontend + backend plugin, built with the Caido SDK; CI typechecks, tests, and builds the package on every push.