### PR TITLE
Add Vigolium

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -947,5 +947,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEALxJ9vDf8SKQOlKmL3UNm/VWuspD1mK1bZeN4uGBxRtU=",
     "repository": "0x2458bughunt/caido-path-crawler"
+  },
+  {
+    "id": "vigolium",
+    "name": "Vigolium",
+    "license": "MIT",
+    "description": "Send Caido traffic to the Vigolium scanning engine, review findings, and bridge traffic with the Vigolium CLI and server",
+    "author": {
+      "name": "Vigolium",
+      "email": "jessie@vigolium.com",
+      "url": "https://github.com/vigolium/vigolium"
+    },
+    "public_key": "MCowBQYDK2VwAyEATha5rzZMhng0Bvv3hMGeOs/CSVUnRZRXmsQIRz8EIuk=",
+    "repository": "vigolium/caido-vigolium"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Plugin Package

## Repository URL

Link to my plugin package: https://github.com/vigolium/caido-vigolium

Release: https://github.com/vigolium/caido-vigolium/releases/tag/0.1.1

## Release Checklist

- [x] I have tested the plugin on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
- [x] My GitHub release contains all required files
  - [x] `plugin_package.zip`
  - [x] `plugin_package.zip.sig`
- [x] Release immutability is enabled
- [x] GitHub Tag name matches the version number specified in my `caido.config.json`
- [x] The `id` in my `caido.config.json` matches the `id` in the `plugin_packages.json` file.
- [x] My `README.md` describes the plugin package purpose and provides clear usage instructions.
- [x] I have read the developer policy at <https://developer.caido.io/policy.html>, and have assessed my plugin package adherence to this policy.
- [x] I have added a license in the `LICENSE` file and it matches the `license` field in the `plugin_packages.json` file.
- [x] My project respects and is compatible with the original license of any third-party code that I'm using.
      I have given proper attribution to these other projects in my `README.md` and/or `LICENSE`.

## Notes

The plugin is built with a plain pnpm workspace rather than the scaffold, so the plugin `id` and `version` live in `manifest.json` instead of `caido.config.json`. The tag `0.1.1` matches `manifest.json`, and the `id` is `vigolium` in both `manifest.json` and this entry.

Vigolium is a scanning engine the user runs themselves, by default on `http://127.0.0.1:9002`. There is no Vigolium account, no paid tier, no telemetry, and no remote asset loading. The external service dependency and data handling are disclosed under [External services and data handling](https://github.com/vigolium/caido-vigolium#external-services-and-data-handling) in the README.
