### PR TITLE
Add JS Secrets

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -960,5 +960,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEATha5rzZMhng0Bvv3hMGeOs/CSVUnRZRXmsQIRz8EIuk=",
     "repository": "vigolium/caido-vigolium"
+  },
+  {
+    "id": "jssecrets",
+    "name": "JS Secrets",
+    "license": "MIT",
+    "description": "Scans proxied JavaScript files for leaked API keys, tokens and credentials",
+    "author": {
+      "name": "Diego Espindola",
+      "email": "espindola@protonmail.com",
+      "url": "https://github.com/diegoespindola"
+    },
+    "public_key": "MCowBQYDK2VwAyEAqsL7o+33q9Lo+f4QDXy8nvC/ZH8B+UQE2zt1xSKoMbc=",
+    "repository": "diegoespindola/jssecrets-caido-plugin"
   }
 ]


### PR DESCRIPTION
## Plugin
[JS Secrets](https://github.com/diegoespindola/jssecrets-caido-plugin) — scans proxied JavaScript files for leaked API keys, tokens and credentials, highlighting matches as Findings in HTTP History.

## Checklist
- [x] Repository is public and follows the setup guide
- [x] Immutable releases enabled
- [x] Release published with a signed `plugin_package.zip` (ed25519)
- [x] `plugin_packages.json` entry added with matching `public_key`