### PR TITLE
Add AI Recon Watcher

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -999,5 +999,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAjpvyPGmqgAQyiXEN4DtR345SgvmnfptLcBQ2VVPnKKc=",
     "repository": "hahwul/ShadowShell"
+  },
+  {
+    "id": "ai-recon-watcher",
+    "name": "AI Recon Watcher",
+    "license": "MIT",
+    "description": "Passively watches HTTP traffic through Caido, stores every request/response as JSON, and flags tech-stack, AI-system, and attack-surface signals as Findings - no active probing.",
+    "author": {
+      "name": "ajayvb03",
+      "email": "ajaybechawade@gmail.com",
+      "url": "https://github.com/ajayvb03"
+    },
+    "public_key": "MCowBQYDK2VwAyEAgnmUjobDBDWX8tUlWSQwzQ5MEFDrKhe0FuolgALZ4aA=",
+    "repository": "ajayvb03/ai-recon-watcher"
   }
 ]


### PR DESCRIPTION
## Plugin

**AI Recon Watcher** — passively watches HTTP traffic through Caido, stores every request/response as JSON, and flags tech-stack, AI-system, and attack-surface signals as Findings. No active probing.

- Repository: https://github.com/ajayvb03/ai-recon-watcher
- License: MIT
- Signed release: https://github.com/ajayvb03/ai-recon-watcher/releases/tag/0.6.1

## Checklist
- [x] GitHub release published, tagged with the manifest version, marked immutable
- [x] Release signed with an Ed25519 keypair via the repo's release workflow
- [x] CLA signed
- [x] Entry added to `plugin_packages.json` (this PR)