### PR TITLE
Add DefMiner

### DIFF
--- a/plugin_packages.json
+++ b/plugin_packages.json
@@ -1012,5 +1012,18 @@
     },
     "public_key": "MCowBQYDK2VwAyEAgnmUjobDBDWX8tUlWSQwzQ5MEFDrKhe0FuolgALZ4aA=",
     "repository": "ajayvb03/ai-recon-watcher"
+  },
+  {
+    "id": "defminer",
+    "name": "DefMiner",
+    "license": "MIT",
+    "description": "Passive JavaScript inventory for Caido: stores every script a target serves once by digest, reconstructs original sources from inline source maps, and retroactively scans traffic captured before it was installed.",
+    "author": {
+      "name": "six2dez",
+      "email": "six2dez@gmail.com",
+      "url": "https://github.com/six2dez"
+    },
+    "public_key": "MCowBQYDK2VwAyEAbttdEsqRZEFeMGU63rS241Q+KTc9oARmL1/SBw5LE/U=",
+    "repository": "six2dez/DefMiner"
   }
 ]


### PR DESCRIPTION
Adds **DefMiner** to the store.

### What it does

A passive JavaScript inventory. It watches proxied responses as you browse,
stores each script once by digest with every place it was observed, and
reconstructs the original sources from inline source maps into a browsable
tree. It also scans traffic Caido captured *before* the plugin was installed.

It makes no outbound requests of its own — every byte it analyses comes from
traffic Caido already captured, and an external `.map` referenced by URL is
counted but never fetched.

To be explicit about scope, since the name suggests more: **it does not scan for
secrets, endpoints or other findings.** It tells you what JavaScript exists and
what its original source says. Detection is a later phase, and the README and
the in-plugin Help tab both say so.

### Details

| | |
|---|---|
| Repository | https://github.com/six2dez/DefMiner |
| License | MIT |
| Release | [`0.1.0`](https://github.com/six2dez/DefMiner/releases/tag/0.1.0) |
| Assets | `plugin_package.zip` + `plugin_package.zip.sig` |

The release is signed with the Ed25519 key whose public half is in this entry;
I verified `openssl pkeyutl -verify` against the published artifact before
opening this PR.

### Checks

- `plugin_packages.json` validates against `schema.json` (draft-07), 79 entries
- `id` is `defminer`, matching the plugin manifest
- Diff is a pure append — 13 insertions, 0 deletions, no other entry touched